### PR TITLE
Fix/disable package-mode to resolve installation error

### DIFF
--- a/ispitch-api/pyproject.toml
+++ b/ispitch-api/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "librosa (>=0.11.0,<0.12.0)"
 ]
 
+[tool.poetry]
+package-mode = false
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
Disabling package-mode prevents installation errors related to package management.