### PR TITLE
 [TASK] Refatoração das requisições

### DIFF
--- a/frontend/src/app/(public)/page.tsx
+++ b/frontend/src/app/(public)/page.tsx
@@ -13,7 +13,7 @@ export default function HomePage() {
     handleFileAccepted,
     handleUpload,
     handleCancel,
-    setError,
+    handleValidationError,
   } = useAudioUpload();
 
   return (
@@ -29,7 +29,7 @@ export default function HomePage() {
         ) : (
           <AudioDropzone 
             onFileAccepted={handleFileAccepted} 
-            onError={setError}
+            onValidationError={handleValidationError}
           />
         )}
 

--- a/frontend/src/components/features/AudioDropzone.tsx
+++ b/frontend/src/components/features/AudioDropzone.tsx
@@ -7,7 +7,7 @@ import { UploadCloud } from 'lucide-react';
 
 interface AudioDropzoneProps {
   onFileAccepted: (file: File) => void;
-  onError: (message: string) => void;
+  onValidationError: (message: string) => void;
 }
 
 const audioValidator = (file: File) => {
@@ -29,14 +29,14 @@ const audioValidator = (file: File) => {
 };
 
 
-export function AudioDropzone({ onFileAccepted, onError }: AudioDropzoneProps) {
+export function AudioDropzone({ onFileAccepted, onValidationError }: AudioDropzoneProps) {
   const onDrop = useCallback(
     (acceptedFiles: File[], fileRejections: FileRejection[]) => {
-      onError(''); 
+      onValidationError(''); 
 
       if (fileRejections.length > 0) {
         const errorMessage = fileRejections[0].errors[0].message;
-        onError(errorMessage);
+        onValidationError(errorMessage);
         return;
       }
 
@@ -44,7 +44,7 @@ export function AudioDropzone({ onFileAccepted, onError }: AudioDropzoneProps) {
         onFileAccepted(acceptedFiles[0]);
       }
     },
-    [onFileAccepted, onError],
+    [onFileAccepted, onValidationError],
   );
 
   const { getRootProps, getInputProps, isDragActive, isDragReject } = useDropzone({

--- a/frontend/src/hooks/mutations/useInitiateAnalysis.ts
+++ b/frontend/src/hooks/mutations/useInitiateAnalysis.ts
@@ -1,0 +1,14 @@
+import { initiateAnalysis } from '@/services/analysisService';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation'
+
+export const useInitiateAnalysis = () => {
+    const router = useRouter();
+
+    return useMutation({
+        mutationFn: initiateAnalysis,
+        onSuccess: (analysisId) => {
+            router.push(`/analysis/${analysisId}`);
+        }
+    });
+}

--- a/frontend/src/hooks/queries/useGetAnalysis.ts
+++ b/frontend/src/hooks/queries/useGetAnalysis.ts
@@ -1,0 +1,17 @@
+import { getAnalysis } from '@/services/analysisService'
+import { Analysis } from '@/types/analysis'
+import { useQuery } from '@tanstack/react-query'
+
+
+export const useGetAnalysis = (id: string) => {
+    return useQuery<Analysis, Error>({
+        queryKey: ['analysis', id],
+        queryFn: () => getAnalysis(id),
+        enabled: !!id,
+        refetchInterval: (query) => {
+            const data = query.state.data;
+            return data?.status === 'PENDING' ? 3000 : false;
+        },
+        retry: false,
+    });
+}

--- a/frontend/src/hooks/useAudioUpload.ts
+++ b/frontend/src/hooks/useAudioUpload.ts
@@ -1,48 +1,42 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { createAudioAnalysis } from '@/services/analysisService';
+import { useInitiateAnalysis } from './mutations/useInitiateAnalysis';
 
 export function useAudioUpload() {
     const [audioFile, setAudioFile] = useState<File | null>(null);
-    const [isLoading, setIsLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const router = useRouter();
+    const [validationError, setValidationError] = useState<string | null>(null);
+    const { mutate: uploadAudio, isPending, error: mutationError } = useInitiateAnalysis();
+
+    const error = validationError || mutationError?.message || null;
+
+    const handleValidationError = (message: string) => {
+        setValidationError(message);
+    };
 
     const handleFileAccepted = (file: File) => {
-        setError(null);
+        setValidationError(null);
         setAudioFile(file);
     };
 
     const handleUpload = async () => {
         if (!audioFile) return;
 
-        setIsLoading(true);
-        setError(null);
-
-        try {
-            const analysisId = await createAudioAnalysis(audioFile);
-            router.push(`/analysis/${analysisId}`);
-        } catch (err) {
-            const errorMessage = err instanceof Error ? err.message : 'Ocorreu um erro desconhecido durante o upload.';
-            setError(errorMessage);
-            setIsLoading(false);
-        }
+        uploadAudio(audioFile);
     };
 
     const handleCancel = () => {
         setAudioFile(null);
-        setError(null);
+        setValidationError(null);
     };
 
     return {
         audioFile,
-        isLoading,
+        isLoading: isPending,
         error,
         handleFileAccepted,
         handleUpload,
         handleCancel,
-        setError,
+        handleValidationError,
     };
 }

--- a/frontend/src/services/analysisService.ts
+++ b/frontend/src/services/analysisService.ts
@@ -5,7 +5,7 @@ import type { Analysis } from '@/types/analysis';
  * Uploads an audio file to start a new analysis.
  * Now it just creates the FormData and delegates the call to the apiClient.
  */
-export const createAudioAnalysis = async (audioFile: File): Promise<string> => {
+export const initiateAnalysis = async (audioFile: File): Promise<string> => {
     const formData = new FormData();
     formData.append('file', audioFile);
 


### PR DESCRIPTION
This pull request refactors how the frontend fetches and initiates audio analysis, moving from manual state management and polling to a more robust approach using React Query hooks. The changes improve code readability, maintainability, and ensure more consistent data fetching and navigation behavior.

**Data fetching and polling improvements:**

* Replaced manual polling and state management in `AnalysisPage` with the new `useGetAnalysis` React Query hook, which automatically polls for analysis status and handles loading, error, and data states. 
* Added the `useGetAnalysis` hook, which uses React Query to fetch analysis data, polls every 3 seconds while status is `PENDING`, and disables retries for failed requests.

**Analysis initiation and navigation:**

* Introduced the `useInitiateAnalysis` hook, leveraging React Query for mutation and automatically navigating to the analysis results page upon successful initiation. (`frontend/src/hooks/mutations/useInitiateAnalysis.ts`, 
* Renamed `createAudioAnalysis` to `initiateAnalysis` in the analysis service for clarity and consistency with the new hooks. (`frontend/src/services/analysisService.ts`, 