### PR TITLE
[TASK] Endpoint de Estatísticas Gerais

### DIFF
--- a/ispitch-api/src/analysis/application/dependencies/services.py
+++ b/ispitch-api/src/analysis/application/dependencies/services.py
@@ -11,6 +11,7 @@ from ...application.dependencies.models import (
 )
 from ...domain.ports.input import (
     AnalysisOrchestratorPort,
+    AnalysisStatsPort,
     AudioAnalysisPort,
     LexicalRichnessPort,
     SpeechAnalysisPort,
@@ -31,6 +32,7 @@ from ...domain.services.analysis_orchestrator_service import (
     AnalysisOrchestratorDependencies,
     AnalysisOrchestratorService,
 )
+from ...domain.services.analysis_stats_service import AnalysisStatsService
 from ...domain.services.audio_analysis_service import AudioAnalysisService
 from ...domain.services.lexical_richness_service import LexicalRichnessService
 from ...domain.services.speech_analysis_service import SpeechAnalysisService
@@ -38,27 +40,18 @@ from ...domain.services.topic_analysis_service import TopicAnalysisService
 from ...domain.services.vocabulary_analysis_service import (
     VocabularyAnalysisService,
 )
-from ...infrastructure.adapters.audio.audio_adapter import AudioAdapter
-from ...infrastructure.adapters.speech.fillerwords_analysis_adapter import (
-    FillerWordsAnalysisAdapter,
-)
-from ...infrastructure.adapters.task_queue.celery_adapter import (
+from ...infrastructure.adapters import (
+    AudioAdapter,
     CeleryTaskQueueAdapter,
-)
-from ...infrastructure.adapters.topics.huggingface_adapter import (
+    FillerWordsAnalysisAdapter,
     HuggingFaceTopicAdapter,
-)
-from ...infrastructure.adapters.transcription.whisper_adapter import (
+    NltkSynonymProviderAdapter,
     WhisperAdapter,
 )
-from ...infrastructure.adapters.vocabulary.nltk_adapter import (
-    NltkSynonymProviderAdapter,
-)
 from ...infrastructure.context.resource_manager import ResourceManager
-from ...infrastructure.persistance.adapters.analysis_repository_adapter import (
+from ...infrastructure.persistance.adapters import (
     AnalysisRepositoryAdapter,
-)
-from ...infrastructure.persistance.adapters.storage_adapter import (
+    AnalysisStatsRepositoryAdapter,
     StorageAdapter,
 )
 from ..adapters.sse_adapter import RedisSSEAdapter
@@ -140,3 +133,9 @@ def get_topic_model_port() -> TopicModelPort:
 def get_topic_analysis_port() -> TopicAnalysisPort:
     load_nltk_tokenizer()
     return TopicAnalysisService(get_topic_model_port())
+
+
+@lru_cache(maxsize=1)
+def get_analysis_stats_service() -> AnalysisStatsPort:
+    stats_repository = AnalysisStatsRepositoryAdapter()
+    return AnalysisStatsService(stats_repository)

--- a/ispitch-api/src/analysis/application/mappers/analysis_stats_mapper.py
+++ b/ispitch-api/src/analysis/application/mappers/analysis_stats_mapper.py
@@ -1,0 +1,28 @@
+from ...domain.models.analysis_stats import AnalysisStats
+from ..rest.schemas.analysis_stats import (
+    AnalysisStatsSchema,
+    ChartDataSchema,
+)
+
+
+class AnalysisStatsMapper:
+    @staticmethod
+    def from_model(stats: AnalysisStats) -> AnalysisStatsSchema:
+        """
+        Converts domain model to response schema.
+
+        Args:
+            stats: AnalysisStats domain model.
+
+        Returns:
+            AnalysisStatsSchema for API response.
+        """
+        return AnalysisStatsSchema(
+            total_analyses=stats.total_analyses,
+            total_filler_words=stats.total_filler_words,
+            total_duration=stats.total_duration,
+            chart_data=[
+                ChartDataSchema(name=chart.name, analyses=chart.analyses)
+                for chart in stats.chart_data
+            ],
+        )

--- a/ispitch-api/src/analysis/application/rest/schemas/analysis_stats.py
+++ b/ispitch-api/src/analysis/application/rest/schemas/analysis_stats.py
@@ -1,0 +1,13 @@
+from src.core.schemas.camel_case_model import CamelCaseModel
+
+
+class ChartDataSchema(CamelCaseModel):
+    name: str
+    analyses: int
+
+
+class AnalysisStatsSchema(CamelCaseModel):
+    total_analyses: int
+    total_filler_words: int
+    total_duration: float
+    chart_data: list[ChartDataSchema]

--- a/ispitch-api/src/analysis/domain/models/analysis_stats.py
+++ b/ispitch-api/src/analysis/domain/models/analysis_stats.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ChartData:
+    name: str
+    analyses: int
+
+
+@dataclass
+class AnalysisStats:
+    total_analyses: int
+    total_filler_words: int
+    total_duration: float
+    chart_data: list[ChartData]

--- a/ispitch-api/src/analysis/domain/ports/input.py
+++ b/ispitch-api/src/analysis/domain/ports/input.py
@@ -4,6 +4,7 @@ from typing import List
 from fastapi import BackgroundTasks, UploadFile
 
 from ..models.analysis import Analysis
+from ..models.analysis_stats import AnalysisStats
 from ..models.fillerwords import FillerWordsAnalysis
 from ..models.lexical_richness import LexicalRichnessAnalysis
 from ..models.silence import SilenceAnalysis
@@ -86,4 +87,10 @@ class LexicalRichnessPort(ABC):
 class TopicAnalysisPort(ABC):
     @abstractmethod
     def analyze(self, transcription: Transcription) -> TopicAnalysis:
+        pass
+
+
+class AnalysisStatsPort(ABC):
+    @abstractmethod
+    async def get_stats(self, user_id: str) -> AnalysisStats:
         pass

--- a/ispitch-api/src/analysis/domain/ports/output.py
+++ b/ispitch-api/src/analysis/domain/ports/output.py
@@ -5,6 +5,7 @@ from fastapi import UploadFile
 
 from src.analysis.domain.models.analysis import Analysis
 
+from ..models.analysis_stats import AnalysisStats
 from ..models.events import SseEvent
 from ..models.fillerwords import FillerWordsAnalysis
 from ..models.topic import TopicAnalysis
@@ -86,4 +87,10 @@ class SynonymProviderPort(ABC):
 class TopicModelPort(ABC):
     @abstractmethod
     def extract_topics(self, text: str) -> TopicAnalysis:
+        pass
+
+
+class AnalysisStatsRepositoryPort(ABC):
+    @abstractmethod
+    async def get_stats(self, user_id: str) -> AnalysisStats:
         pass

--- a/ispitch-api/src/analysis/domain/services/analysis_stats_service.py
+++ b/ispitch-api/src/analysis/domain/services/analysis_stats_service.py
@@ -1,0 +1,11 @@
+from ..models.analysis_stats import AnalysisStats
+from ..ports.input import AnalysisStatsPort
+from ..ports.output import AnalysisStatsRepositoryPort
+
+
+class AnalysisStatsService(AnalysisStatsPort):
+    def __init__(self, stats_repository: AnalysisStatsRepositoryPort):
+        self.stats_repository = stats_repository
+
+    async def get_stats(self, user_id: str) -> AnalysisStats:
+        return await self.stats_repository.get_stats(user_id)

--- a/ispitch-api/src/analysis/infrastructure/adapters/__init__.py
+++ b/ispitch-api/src/analysis/infrastructure/adapters/__init__.py
@@ -1,0 +1,17 @@
+from .audio.audio_adapter import AudioAdapter
+from .notification.redis_adapter import RedisNotificationAdapter
+from .speech.fillerwords_analysis_adapter import FillerWordsAnalysisAdapter
+from .task_queue.celery_adapter import CeleryTaskQueueAdapter
+from .topics.huggingface_adapter import HuggingFaceTopicAdapter
+from .transcription.whisper_adapter import WhisperAdapter
+from .vocabulary.nltk_adapter import NltkSynonymProviderAdapter
+
+__all__ = [
+    'AudioAdapter',
+    'RedisNotificationAdapter',
+    'FillerWordsAnalysisAdapter',
+    'CeleryTaskQueueAdapter',
+    'WhisperAdapter',
+    'NltkSynonymProviderAdapter',
+    'HuggingFaceTopicAdapter',
+]

--- a/ispitch-api/src/analysis/infrastructure/persistance/adapters/__init__.py
+++ b/ispitch-api/src/analysis/infrastructure/persistance/adapters/__init__.py
@@ -1,0 +1,9 @@
+from .analysis_repository_adapter import AnalysisRepositoryAdapter
+from .analysis_stats_repository_adapter import AnalysisStatsRepositoryAdapter
+from .storage_adapter import StorageAdapter
+
+__all__ = [
+    'AnalysisRepositoryAdapter',
+    'AnalysisStatsRepositoryAdapter',
+    'StorageAdapter',
+]

--- a/ispitch-api/src/analysis/infrastructure/persistance/adapters/analysis_stats_repository_adapter.py
+++ b/ispitch-api/src/analysis/infrastructure/persistance/adapters/analysis_stats_repository_adapter.py
@@ -1,0 +1,113 @@
+import asyncio
+from typing import Any
+
+from ....domain.models.analysis_stats import AnalysisStats, ChartData
+from ....domain.ports.output import AnalysisStatsRepositoryPort
+from ..documents.analysis_document import AnalysisDocument
+
+
+class AnalysisStatsRepositoryAdapter(AnalysisStatsRepositoryPort):
+    MONTH_NAMES = [
+        'Jan',
+        'Fev',
+        'Mar',
+        'Abr',
+        'Mai',
+        'Jun',
+        'Jul',
+        'Ago',
+        'Set',
+        'Out',
+        'Nov',
+        'Dez',
+    ]
+
+    async def get_stats(self, user_id: str) -> AnalysisStats:
+        totals_pipeline = [
+            {'$match': {'user_id': user_id}},
+            {
+                '$group': {
+                    '_id': None,
+                    'total_analyses': {'$sum': 1},
+                    'total_filler_words': {
+                        '$sum': '$speech_analysis.fillerwords_analysis.total'
+                    },
+                    'total_duration': {'$sum': '$audio_analysis.duration'},
+                }
+            },
+        ]
+
+        chart_pipeline = [
+            {'$match': {'user_id': user_id}},
+            {
+                '$project': {
+                    'month': {'$month': '$created_at'},
+                    'year': {'$year': '$created_at'},
+                }
+            },
+            {
+                '$group': {
+                    '_id': {'month': '$month', 'year': '$year'},
+                    'analyses': {'$sum': 1},
+                }
+            },
+            {'$sort': {'_id.year': 1, '_id.month': 1}},
+        ]
+
+        totals_result, chart_result = await asyncio.gather(
+            self._run_pipeline(totals_pipeline),
+            self._run_pipeline(chart_pipeline),
+        )
+
+        total_analyses, total_filler_words, total_duration = self._parse_totals(
+            totals_result
+        )
+
+        chart_data = self._build_chart_data(chart_result)
+
+        return AnalysisStats(
+            total_analyses=total_analyses,
+            total_filler_words=total_filler_words,
+            total_duration=total_duration,
+            chart_data=chart_data,
+        )
+
+    @staticmethod
+    async def _run_pipeline(
+        pipeline: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        cursor = AnalysisDocument.get_pymongo_collection().aggregate(pipeline)
+        results: list[dict[str, Any]] = []
+        async for doc in cursor:
+            results.append(doc)
+        return results
+
+    @staticmethod
+    def _parse_totals(
+        totals_result: list[dict[str, Any]],
+    ) -> tuple[int, int, float]:
+        if not totals_result:
+            return 0, 0, 0.0
+
+        totals = totals_result[0]
+        total_analyses = totals.get('total_analyses', 0)
+        total_filler_words = totals.get('total_filler_words', 0)
+        total_duration = round(totals.get('total_duration', 0.0), 2)
+        return total_analyses, total_filler_words, total_duration
+
+    def _build_chart_data(
+        self, chart_result: list[dict[str, Any]]
+    ) -> list[ChartData]:
+        chart_data: list[ChartData] = []
+        for item in chart_result:
+            month = item['_id']['month']
+            year = item['_id']['year']
+            analyses_count = item['analyses']
+
+            month_name = self.MONTH_NAMES[month - 1]
+            year_short = str(year)[-2:]
+            name = f'{month_name}/{year_short}'
+
+            chart_data.append(ChartData(name=name, analyses=analyses_count))
+
+        return chart_data


### PR DESCRIPTION
This pull request introduces a new endpoint to provide aggregated analysis statistics for users, including total analyses, filler words, duration, and monthly chart data. The implementation includes new domain models, service, repository adapter, and API schema/mapping logic, as well as necessary dependency and port definitions.

**Analysis Statistics Feature**

* Added `AnalysisStats` and `ChartData` domain models to represent aggregated analysis data and chart breakdowns 
* Introduced `AnalysisStatsPort` and `AnalysisStatsRepositoryPort` interfaces to define the contract for retrieving user statistics 
* Added `AnalysisStatsRepositoryAdapter` to aggregate statistics and chart data from the database using MongoDB pipelines 

**API Endpoint and Mapping**

* Created a new `/v2/analysis/stats` endpoint that returns user statistics, with schema and mapper for API responses 

**Dependency and Adapter Refactoring**

* Refactored imports and adapter initializations to support the new service, including updates to dependency injection and adapter module organization

**Summary:**  
This PR adds a robust analysis statistics feature, including models, service, repository, API endpoint, and all supporting infrastructure. It enables users to retrieve meaningful aggregated statistics about their analyses.