### PR TITLE
feat: Add pagination to user analyses retrieval

### DIFF
--- a/ispitch-api/src/analysis/application/mappers/analysis_schema_mapper.py
+++ b/ispitch-api/src/analysis/application/mappers/analysis_schema_mapper.py
@@ -12,7 +12,7 @@ from ..mappers.topic_analysis_schema_mapper import TopicAnalysisSchemaMapper
 from ..mappers.vocabulary_analysis_schema_mapper import (
     VocabularyAnalysisSchemaMapper,
 )
-from ..rest.schemas.analysis import (
+from ..rest.schemas import (
     AnalysisSchema,
     AnalysisSummarySchema,
     AudioAnalysisSchema,

--- a/ispitch-api/src/analysis/application/rest/endpoints/analysis.py
+++ b/ispitch-api/src/analysis/application/rest/endpoints/analysis.py
@@ -11,6 +11,7 @@ from fastapi import (
 )
 
 from .....auth.application.dependencies.security import authentication
+from .....core.schemas import PaginationMetadata
 from ....application.dependencies.services import (
     get_analysis_orchestrator,
     get_analysis_stats_service,
@@ -26,8 +27,11 @@ from ....domain.ports.input import (
 from ...adapters.sse_adapter import RedisSSEAdapter
 from ...mappers.analysis_schema_mapper import AnalysisSchemaMapper
 from ...mappers.analysis_stats_mapper import AnalysisStatsMapper
-from ..schemas.analysis import AnalysisSchema, AnalysisSummarySchema
-from ..schemas.analysis_stats import AnalysisStatsSchema
+from ..schemas import (
+    AnalysisSchema,
+    AnalysisStatsSchema,
+    AnalysisSummaryResponseSchema,
+)
 
 router_v1 = APIRouter(prefix='/v1/analysis', tags=['Analysis'])
 router_v2 = APIRouter(prefix='/v2/analysis', tags=['Analysis'])
@@ -105,7 +109,7 @@ async def stream_status(
 
 @router_v2.get(
     '/',
-    response_model=list[AnalysisSummarySchema],
+    response_model=AnalysisSummaryResponseSchema,
     summary='Get all user analyses',
     description='Retrieves all analyses created by the authenticated user',
 )
@@ -121,8 +125,16 @@ async def get_user_analyses(
         description='Number of results per page',
     ),
 ):
-    analyses = await orchestrator.get_by_user_id(user_id, page, page_size)
-    return [AnalysisSchemaMapper.to_summary(a) for a in analyses]
+    analyses, total = await orchestrator.get_by_user_id(user_id, page, page_size)
+
+    items = [AnalysisSchemaMapper.to_summary(a) for a in analyses]
+    metadata = PaginationMetadata(
+        total=total,
+        page=page,
+        page_size=page_size,
+        has_more=(page * page_size) < total,
+    )
+    return AnalysisSummaryResponseSchema(analyses=items, metadata=metadata)
 
 
 @router_v2.get(

--- a/ispitch-api/src/analysis/application/rest/schemas/__init__.py
+++ b/ispitch-api/src/analysis/application/rest/schemas/__init__.py
@@ -1,0 +1,15 @@
+from .analysis import AnalysisSchema, AudioAnalysisSchema, SpeechAnalysisSchema
+from .analysis_stats import AnalysisStatsSchema
+from .analysis_summary import (
+    AnalysisSummaryResponseSchema,
+    AnalysisSummarySchema,
+)
+
+__all__ = [
+    'AnalysisSchema',
+    'AnalysisStatsSchema',
+    'AnalysisSummaryResponseSchema',
+    'AudioAnalysisSchema',
+    'SpeechAnalysisSchema',
+    'AnalysisSummarySchema',
+]

--- a/ispitch-api/src/analysis/application/rest/schemas/analysis.py
+++ b/ispitch-api/src/analysis/application/rest/schemas/analysis.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from .....core.schemas.camel_case_model import CamelCaseModel
+from .....core.schemas import CamelCaseModel
 from ..schemas.fillerwords import FillerWordsAnalysisSchema
 from ..schemas.lexical_richness import LexicalRichnessAnalysisSchema
 from ..schemas.silence import SilenceAnalysisSchema
@@ -31,12 +31,3 @@ class AnalysisSchema(CamelCaseModel):
     transcription: Optional[str] = None
     speech_analysis: Optional[SpeechAnalysisSchema] = None
     audio_analysis: Optional[AudioAnalysisSchema] = None
-
-
-class AnalysisSummarySchema(CamelCaseModel):
-    id: str
-    user_id: Optional[str] = None
-    status: str
-    filename: str
-    duration: float
-    created_at: datetime

--- a/ispitch-api/src/analysis/application/rest/schemas/analysis_summary.py
+++ b/ispitch-api/src/analysis/application/rest/schemas/analysis_summary.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from typing import Optional
+
+from .....core.schemas import CamelCaseModel, PaginationMetadata
+
+
+class AnalysisSummarySchema(CamelCaseModel):
+    id: str
+    user_id: Optional[str] = None
+    status: str
+    filename: str
+    duration: float
+    created_at: datetime
+
+
+class AnalysisSummaryResponseSchema(CamelCaseModel):
+    analyses: list[AnalysisSummarySchema]
+    metadata: PaginationMetadata

--- a/ispitch-api/src/analysis/domain/ports/input.py
+++ b/ispitch-api/src/analysis/domain/ports/input.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Tuple
 
 from fastapi import BackgroundTasks, UploadFile
 
@@ -31,7 +31,7 @@ class AnalysisOrchestratorPort(ABC):
     @abstractmethod
     async def get_by_user_id(
         self, user_id: str, page: int, page_size: int
-    ) -> List[Analysis]:
+    ) -> Tuple[List[Analysis], int]:
         pass
 
 

--- a/ispitch-api/src/analysis/domain/ports/output.py
+++ b/ispitch-api/src/analysis/domain/ports/output.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Tuple
 
 from fastapi import UploadFile
 
@@ -52,7 +52,7 @@ class AnalysisRepositoryPort(ABC):
     @abstractmethod
     async def find_by_user_id(
         self, user_id: str, page: int, page_size: int
-    ) -> List[Analysis]:
+    ) -> Tuple[List[Analysis], int]:
         pass
 
     @abstractmethod

--- a/ispitch-api/src/analysis/domain/services/analysis_orchestrator_service.py
+++ b/ispitch-api/src/analysis/domain/services/analysis_orchestrator_service.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Tuple
 
 from ..models.analysis import (
     Analysis,
@@ -117,7 +117,7 @@ class AnalysisOrchestratorService(AnalysisOrchestratorPort):
 
     async def get_by_user_id(
         self, user_id: str, page: int, page_size: int
-    ) -> List[Analysis]:
+    ) -> Tuple[List[Analysis], int]:
         """
         Retrieves all analyses for a specific user by their user ID.
         Args:

--- a/ispitch-api/src/core/schemas/__init__.py
+++ b/ispitch-api/src/core/schemas/__init__.py
@@ -1,0 +1,5 @@
+from .camel_case_model import CamelCaseModel
+from .error import ErrorResponse
+from .pagination_metadata import PaginationMetadata
+
+__all__ = ['CamelCaseModel', 'ErrorResponse', 'PaginationMetadata']

--- a/ispitch-api/src/core/schemas/pagination_metadata.py
+++ b/ispitch-api/src/core/schemas/pagination_metadata.py
@@ -1,0 +1,8 @@
+from .camel_case_model import CamelCaseModel
+
+
+class PaginationMetadata(CamelCaseModel):
+    total: int
+    page: int
+    page_size: int
+    has_more: bool


### PR DESCRIPTION
This pull request introduces pagination support to the API endpoint for retrieving a user's analyses. The changes ensure that clients can request analyses in pages, improving scalability and performance for users with many analyses. The most important changes are grouped below:

**API Endpoint Updates:**

* Added `page` and `page_size` query parameters to the `get_user_analyses` endpoint in `analysis.py`, allowing clients to specify which page and how many results per page they want.
* Included the necessary import for `Query` from FastAPI to support the new query parameters.

**Domain Layer Changes:**

* Updated the input and output port interfaces (`get_by_user_id` and `find_by_user_id`) to accept `page` and `page_size` arguments, ensuring pagination is supported throughout the service and repository layers. 

**Persistence Layer Changes:**

* Implemented pagination logic in the `find_by_user_id` method of the `AnalysisRepositoryAdapter`, using MongoDB's `skip` and `limit` to fetch only the requested subset of analyses, and sorting by `created_at` for consistent ordering.

These changes collectively allow clients to efficiently browse analyses in paginated form, improving usability and backend performance.