### PR TITLE
[TASK] Adicionar filtro de data ao gráfico do dashboard

### DIFF
--- a/frontend/src/app/(private)/dashboard/page.tsx
+++ b/frontend/src/app/(private)/dashboard/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { Box, Typography, Grid, Alert } from '@mui/material';
 import { 
   StatsCardsSkeleton,
@@ -12,13 +13,15 @@ import { useGetDashboardStats, useGetRecentAnalyses } from '@/domain/dashboard/h
 import { RecentAnalysisCard } from '@/components/features/dashboard/RecentAnalysisCard';
 import { AnalysisChartSkeleton } from '@/components/features/dashboard/AnalysisChartSkeleton';
 import { AnalysisChart } from '@/components/features/dashboard/AnalysisChart';
+import { TimeRange } from '@/domain/dashboard/types';
 
 export default function DashboardPage() {
-  const { data: stats, isLoading: statsLoading, error: statsError } = useGetDashboardStats();
+  const [timeRange, setTimeRange] = useState<TimeRange>('month');
+  
+  const { data: stats, isLoading: statsLoading, error: statsError } = useGetDashboardStats(timeRange);
   const { data: recentAnalysis, isLoading: analysesLoading, error: analysesError } = useGetRecentAnalyses();
 
   const error = statsError || analysesError;
-
   return (
     <>
       <Box sx={{ p: { xs: 2, sm: 3, lg: 4 }, position: 'relative' }}>
@@ -36,12 +39,14 @@ export default function DashboardPage() {
           </Alert>
         )}
 
+        {/* Cards de estatísticas */}
         {statsLoading ? (
           <StatsCardsSkeleton />
         ) : (
           <StatsCards stats={stats} />
         )}
 
+        {/* Análise recente */}
         <Grid container spacing={4} sx={{ mt: 2 }}>
           <Grid size={{ xs: 12 }}>
             {analysesLoading ? (
@@ -54,12 +59,18 @@ export default function DashboardPage() {
           </Grid>
         </Grid>
 
+        {/* Gráfico com controles integrados */}
         <Grid container spacing={4} sx={{ mt: 2 }}>
-            <Grid size={{ xs: 12 }}>
+          <Grid size={{ xs: 12 }}>
             {statsLoading ? (
               <AnalysisChartSkeleton />
             ) : stats ? (
-              <AnalysisChart data={stats.chartData} />
+              <AnalysisChart 
+                data={stats.chartData}
+                timeRange={timeRange}
+                onTimeRangeChange={setTimeRange}
+                isLoading={statsLoading}
+              />
             ) : null}
           </Grid>
         </Grid>

--- a/frontend/src/domain/dashboard/hooks/useDashboard.ts
+++ b/frontend/src/domain/dashboard/hooks/useDashboard.ts
@@ -1,13 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { DashboardStats, RecentAnalysis } from '../types/dashboard';
+import { DashboardStats, RecentAnalysis, TimeRange } from '../types/dashboard';
 import { getDashboardStats, getRecentAnalysis } from '../services/dashboardService';
 
 
-export const useGetDashboardStats = () => {
+export const useGetDashboardStats = (timeRange: TimeRange = 'month') => {
     return useQuery<DashboardStats, Error>({
-        queryKey: ['dashboard', 'stats'],
-        queryFn: getDashboardStats,
+        queryKey: ['dashboard', 'stats', timeRange],
+        queryFn: () => getDashboardStats(timeRange),
         staleTime: 1000 * 60 * 5, // 5 minutos
     });
 };

--- a/frontend/src/domain/dashboard/services/dashboardService.ts
+++ b/frontend/src/domain/dashboard/services/dashboardService.ts
@@ -1,17 +1,17 @@
 import { apiRequest } from '@/lib/api';
-import { DashboardStats, RecentAnalysis } from '../types/dashboard';
+import { DashboardStats, RecentAnalysis, TimeRange } from '../types/dashboard';
 import { mockDashboardStats, mockRecentAnalyses } from '../mocks/dashboard.mock.data';
 
 const USE_MOCK_DATA = process.env.NEXT_PUBLIC_USE_MOCK_DATA === 'true';
 
-export const getDashboardStats = async (): Promise<DashboardStats> => {
+export const getDashboardStats = async (timeRange: TimeRange = 'month'): Promise<DashboardStats> => {
     if (USE_MOCK_DATA) {
         await new Promise(resolve => setTimeout(resolve, 1500));
         return mockDashboardStats;
     }
 
     return apiRequest<DashboardStats>({
-        url: '/v2/analysis/stats',
+        url: `/v2/analysis/stats?timeRange=${timeRange}`,
         options: {
             method: 'GET',
         },

--- a/frontend/src/domain/dashboard/types/dashboard.ts
+++ b/frontend/src/domain/dashboard/types/dashboard.ts
@@ -1,3 +1,5 @@
+export type TimeRange = 'day' | 'month' | 'year' | 'all';
+
 export interface DashboardStats {
     totalAnalyses: number;
     totalFillerWords: number;

--- a/frontend/src/domain/dashboard/types/index.ts
+++ b/frontend/src/domain/dashboard/types/index.ts
@@ -1,1 +1,1 @@
-export type { ChartData, RecentAnalysis, DashboardStats } from './dashboard';
+export type { ChartData, RecentAnalysis, DashboardStats, TimeRange } from './dashboard';

--- a/ispitch-api/src/analysis/application/rest/endpoints/analysis.py
+++ b/ispitch-api/src/analysis/application/rest/endpoints/analysis.py
@@ -20,6 +20,7 @@ from ....application.dependencies.services import (
 from ....application.dependencies.validations import (
     validate_audio_file,
 )
+from ....domain.models.time_range import TimeRange
 from ....domain.ports.input import (
     AnalysisOrchestratorPort,
     AnalysisStatsPort,
@@ -149,8 +150,12 @@ async def get_user_analyses(
 async def get_analysis_stats(
     stats_service: AnalysisStatsPort = Depends(get_analysis_stats_service),
     user_id: str = Depends(authentication),
+    time_range: TimeRange = Query(
+        alias='timeRange',
+        default=TimeRange.MONTH,
+    ),
 ) -> AnalysisStatsSchema:
-    stats = await stats_service.get_stats(user_id)
+    stats = await stats_service.get_stats(user_id, time_range)
     return AnalysisStatsMapper.from_model(stats)
 
 

--- a/ispitch-api/src/analysis/domain/models/time_range.py
+++ b/ispitch-api/src/analysis/domain/models/time_range.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class TimeRange(str, Enum):
+    DAY = 'day'
+    MONTH = 'month'
+    YEAR = 'year'
+    ALL = 'all'

--- a/ispitch-api/src/analysis/domain/ports/input.py
+++ b/ispitch-api/src/analysis/domain/ports/input.py
@@ -8,6 +8,7 @@ from ..models.analysis_stats import AnalysisStats
 from ..models.fillerwords import FillerWordsAnalysis
 from ..models.lexical_richness import LexicalRichnessAnalysis
 from ..models.silence import SilenceAnalysis
+from ..models.time_range import TimeRange
 from ..models.topic import TopicAnalysis
 from ..models.transcription import Transcription
 from ..models.vocabulary import VocabularyAnalysis
@@ -98,5 +99,7 @@ class TopicAnalysisPort(ABC):
 
 class AnalysisStatsPort(ABC):
     @abstractmethod
-    async def get_stats(self, user_id: str) -> AnalysisStats:
+    async def get_stats(
+        self, user_id: str, time_range: TimeRange
+    ) -> AnalysisStats:
         pass

--- a/ispitch-api/src/analysis/domain/ports/output.py
+++ b/ispitch-api/src/analysis/domain/ports/output.py
@@ -8,6 +8,7 @@ from src.analysis.domain.models.analysis import Analysis
 from ..models.analysis_stats import AnalysisStats
 from ..models.events import SseEvent
 from ..models.fillerwords import FillerWordsAnalysis
+from ..models.time_range import TimeRange
 from ..models.topic import TopicAnalysis
 from ..models.transcription import Transcription
 
@@ -98,5 +99,7 @@ class TopicModelPort(ABC):
 
 class AnalysisStatsRepositoryPort(ABC):
     @abstractmethod
-    async def get_stats(self, user_id: str) -> AnalysisStats:
+    async def get_stats(
+        self, user_id: str, time_range: TimeRange
+    ) -> AnalysisStats:
         pass

--- a/ispitch-api/src/analysis/domain/services/analysis_stats_service.py
+++ b/ispitch-api/src/analysis/domain/services/analysis_stats_service.py
@@ -1,4 +1,5 @@
 from ..models.analysis_stats import AnalysisStats
+from ..models.time_range import TimeRange
 from ..ports.input import AnalysisStatsPort
 from ..ports.output import AnalysisStatsRepositoryPort
 
@@ -7,5 +8,7 @@ class AnalysisStatsService(AnalysisStatsPort):
     def __init__(self, stats_repository: AnalysisStatsRepositoryPort):
         self.stats_repository = stats_repository
 
-    async def get_stats(self, user_id: str) -> AnalysisStats:
-        return await self.stats_repository.get_stats(user_id)
+    async def get_stats(
+        self, user_id: str, time_range: TimeRange
+    ) -> AnalysisStats:
+        return await self.stats_repository.get_stats(user_id, time_range)

--- a/ispitch-api/src/analysis/infrastructure/persistance/adapters/analysis_stats_repository_adapter.py
+++ b/ispitch-api/src/analysis/infrastructure/persistance/adapters/analysis_stats_repository_adapter.py
@@ -1,9 +1,13 @@
 import asyncio
-from typing import Any
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
 
 from ....domain.models.analysis_stats import AnalysisStats, ChartData
+from ....domain.models.time_range import TimeRange
 from ....domain.ports.output import AnalysisStatsRepositoryPort
 from ..documents.analysis_document import AnalysisDocument
+
+SECONDS_TO_MINUTES = 60
 
 
 class AnalysisStatsRepositoryAdapter(AnalysisStatsRepositoryPort):
@@ -22,9 +26,17 @@ class AnalysisStatsRepositoryAdapter(AnalysisStatsRepositoryPort):
         'Dez',
     ]
 
-    async def get_stats(self, user_id: str) -> AnalysisStats:
+    async def get_stats(
+        self, user_id: str, time_range: TimeRange
+    ) -> AnalysisStats:
+        base_match = {'user_id': user_id, 'status': 'completed'}
+        time_filter = self._get_time_filter(time_range)
+
+        if time_filter:
+            base_match.update(time_filter)
+
         totals_pipeline = [
-            {'$match': {'user_id': user_id}},
+            {'$match': base_match},
             {
                 '$group': {
                     '_id': None,
@@ -37,21 +49,14 @@ class AnalysisStatsRepositoryAdapter(AnalysisStatsRepositoryPort):
             },
         ]
 
+        chart_grouping = self._get_chart_grouping(time_range)
+        name_projection = self._get_name_projection(time_range)
+
         chart_pipeline = [
-            {'$match': {'user_id': user_id}},
-            {
-                '$project': {
-                    'month': {'$month': '$created_at'},
-                    'year': {'$year': '$created_at'},
-                }
-            },
-            {
-                '$group': {
-                    '_id': {'month': '$month', 'year': '$year'},
-                    'analyses': {'$sum': 1},
-                }
-            },
-            {'$sort': {'_id.year': 1, '_id.month': 1}},
+            {'$match': base_match},
+            {'$group': {'_id': chart_grouping, 'analyses': {'$sum': 1}}},
+            {'$sort': {'_id': 1}},
+            {'$project': {'_id': 0, 'name': name_projection, 'analyses': 1}},
         ]
 
         totals_result, chart_result = await asyncio.gather(
@@ -92,21 +97,78 @@ class AnalysisStatsRepositoryAdapter(AnalysisStatsRepositoryPort):
         totals = totals_result[0]
         total_analyses = totals.get('total_analyses', 0)
         total_filler_words = totals.get('total_filler_words', 0)
-        total_duration = round(totals.get('total_duration', 0.0), 2)
+        total_duration = round(
+            totals.get('total_duration', 0) / SECONDS_TO_MINUTES
+        )
         return total_analyses, total_filler_words, total_duration
 
-    def _build_chart_data(
-        self, chart_result: list[dict[str, Any]]
-    ) -> list[ChartData]:
+    @staticmethod
+    def _build_chart_data(chart_result: list[dict[str, Any]]) -> list[ChartData]:
         chart_data: list[ChartData] = []
         for item in chart_result:
-            month = item['_id']['month']
-            analyses_count = item['analyses']
-
-            month_name = self.MONTH_NAMES[month - 1]
-
-            chart_data.append(
-                ChartData(name=month_name, analyses=analyses_count)
-            )
+            name = item.get('name')
+            analyses_count = item.get('analyses', 0)
+            chart_data.append(ChartData(name=name, analyses=analyses_count))
 
         return chart_data
+
+    @staticmethod
+    def _get_time_filter(time_range: TimeRange) -> Optional[dict]:
+        if time_range == TimeRange.ALL:
+            return None
+
+        now = datetime.now(timezone.utc)
+
+        if time_range == TimeRange.DAY:
+            start_date = now - timedelta(days=1)
+        elif time_range == TimeRange.MONTH:
+            start_date = now - timedelta(days=30)
+        elif time_range == TimeRange.YEAR:
+            start_date = now - timedelta(days=365)
+        else:
+            return None
+
+        return {'created_at': {'$gte': start_date}}
+
+    @staticmethod
+    def _get_chart_grouping(time_range: TimeRange) -> dict:
+        if time_range == TimeRange.DAY:
+            return {
+                'year': {'$year': '$created_at'},
+                'month': {'$month': '$created_at'},
+                'day': {'$dayOfMonth': '$created_at'},
+                'hour': {'$hour': '$created_at'},
+            }
+        elif time_range == TimeRange.MONTH:
+            # Agrupa por dia
+            return {
+                'year': {'$year': '$created_at'},
+                'month': {'$month': '$created_at'},
+                'day': {'$dayOfMonth': '$created_at'},
+            }
+        else:
+            # Agrupa por mês
+            return {
+                'year': {'$year': '$created_at'},
+                'month': {'$month': '$created_at'},
+            }
+
+    def _get_name_projection(self, time_range: TimeRange) -> dict:
+        # Depois do $group o campo de agrupamento fica em "_id"
+        if time_range == TimeRange.DAY:
+            return {'$concat': [{'$toString': '$_id.hour'}, 'h']}
+        elif time_range == TimeRange.MONTH:
+            return {
+                '$concat': [
+                    {'$toString': '$_id.day'},
+                    '/',
+                    {'$toString': '$_id.month'},
+                ]
+            }
+        else:
+            return {
+                '$arrayElemAt': [
+                    self.MONTH_NAMES,
+                    {'$subtract': ['$_id.month', 1]},
+                ]
+            }


### PR DESCRIPTION
This pull request introduces a time range filter for dashboard statistics, allowing users to view analytics for different periods (day, month, year, all) both in the frontend and backend. The changes include updates to API endpoints, data fetching hooks, and UI components to support interactive time range selection and display.

**Frontend: Time Range Selection and Integration**
- Added a `TimeRange` type and integrated time range selection into the dashboard statistics and chart, allowing users to filter data by period. The `AnalysisChart` component now receives `timeRange`, `onTimeRangeChange`, and `isLoading` props, and displays a toggle button group for selecting the time range.
- Updated the dashboard stats hook and service to pass the selected time range to the API, ensuring data is fetched for the correct period. 
- Improved chart UI with a badge showing the active time range, updated labels ("Média", "Pico", "Tendência"), and a footer indicating real-time data updates.

**Backend: Time Range Support in Statistics Endpoint**
- Added a `TimeRange` enum model and updated the statistics API endpoint to accept a `timeRange` query parameter, passing it through the service and repository layers. 

**Type and Export Updates**
- Exported the new `TimeRange` type for use across the frontend domain modules.

These changes collectively enable dynamic filtering of dashboard analytics by time range, improving user insight and interactivity.